### PR TITLE
Remove mclf link in intro on about page

### DIFF
--- a/about/index.html
+++ b/about/index.html
@@ -51,7 +51,7 @@
 
 				<h1>About</h1>
 
-				<p><a href="http://marieflanagan.com/">Marie LeBlanc Flanagan </a>is an artist working in the playful
+				<p><!--<a href="http://marieflanagan.com/">Marie LeBlanc Flanagan </a>-->Marie LeBlanc Flanagan is an artist working in the playful
 					spaces
 					between people, especially related to connection and community. Marie has spoken, shared work, and
 					taught workshops in South America, North America, Africa, and Europe. Marie has completed artist


### PR DESCRIPTION
Commented out the link for “[Marie LeBlanc Flanagan](http://marieflanagan.com/)” in first sentence. I don’t think it’s needed here because there’s already a link on the page that points to the site’s landing page 